### PR TITLE
Disable the local part of package versions

### DIFF
--- a/.github/workflows/dissect-ci-template.yml
+++ b/.github/workflows/dissect-ci-template.yml
@@ -22,6 +22,8 @@ jobs:
           cache: "pip"
           cache-dependency-path: "setup.py"
       - run: pip install tox
+      - if: ${{ github.ref_name == 'main' }}
+        run: sed -i 's/\[tool.setuptools_scm\]/\[tool.setuptools_scm\]\nlocal_scheme = "no-local-version"/' pyproject.toml
       - env:
           C_INCLUDE_PATH: ${{ env.pythonLocation }}/include/python3.9
         run: tox -e build
@@ -50,6 +52,8 @@ jobs:
           name: packages
           path: dist/
       - run: pip install tox
+      - if: ${{ github.ref_name == 'main' }}
+        run: sed -i 's/\[tool.setuptools_scm\]/\[tool.setuptools_scm\]\nlocal_scheme = "no-local-version"/' pyproject.toml
       - env:
           C_INCLUDE_PATH: ${{ env.pythonLocation }}/include/python3.9
         run: tox -e lint
@@ -88,6 +92,8 @@ jobs:
           path: dist/
       - if: ${{ inputs.run_tests == true }}
         run: pip install tox
+      - if: ${{ inputs.run_tests == true && github.ref_name == 'main' }}
+        run: sed -i 's/\[tool.setuptools_scm\]/\[tool.setuptools_scm\]\nlocal_scheme = "no-local-version"/' pyproject.toml
       - if: ${{ inputs.run_tests == true }}
         env:
           C_INCLUDE_PATH: ${{ env.pythonLocation }}/include/${{ matrix.python-include }}
@@ -107,7 +113,7 @@ jobs:
 
   publish:
     needs: [lint, test]
-    if: ${{ github.ref_type == 'tag' }}
+    if: ${{ github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest-sh
     steps:
       - uses: actions/setup-python@v4


### PR DESCRIPTION
PyPI does not accept Python packages with a local part in the version number (e.g. +g84953ff). When building the packages for a commit on the main branch, the local part is now turned off by temporarily modifying the setuptools_scm settings in pyproject.toml.

Packages build form other branches retain the local part so as to not have conflicting version numbers with those build from the main branch.

As a consequence all packages, also the .dev versions, build from the main branch can now be published once again on PyPI.

(DIS-1584)