### PR TITLE
Add a job to trigger another project's workflow

### DIFF
--- a/.github/workflows/dissect-ci-template.yml
+++ b/.github/workflows/dissect-ci-template.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: boolean
         default: true
+      on-demand-test:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -138,3 +142,19 @@ jobs:
           path: dist/*.asc
           retention-days: 1
       - run: /tools/publish dist/*
+
+  on-demand-test:
+    needs: [publish]
+    if: ${{ inputs.on-demand-test != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          REPO_NAME: ${{ inputs.on-demand-test }}
+        run: |
+          curl \
+               --no-progress-meter \
+               -X POST \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer ${{ secrets.DISSECT_PA_TOKEN }}" \
+               "https://api.github.com/repos/fox-it/${REPO_NAME}/dispatches" \
+               -d '{"event_type":"on-demand-test"}'


### PR DESCRIPTION
Projects using the CI template can trigger another project's tests by calling the template with an 'on-demand-test' parameter containing the name of the project to trigger. After publishing, the other project is send an repository_dispatch event with the event_type set to "on-demand-test".

(DIS-812)