### PR TITLE
Add an option to install debian packages

### DIFF
--- a/.github/workflows/dissect-ci-template.yml
+++ b/.github/workflows/dissect-ci-template.yml
@@ -10,11 +10,17 @@ on:
         required: false
         type: string
         default: ""
+      deb-packages:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - if: ${{ inputs.deb-packages != '' }}
+        run: sudo apt-get install -qq ${{ inputs.deb-packages }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -76,6 +82,8 @@ jobs:
             python-include: "pypy3.9"
             tox-env: "pypy39"
     steps:
+      - if: ${{ inputs.run_tests == true && inputs.deb-packages != '' }}
+        run: sudo apt-get install -qq ${{ inputs.deb-packages }}
       - if: ${{ inputs.run_tests == true }}
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The specified packages in a caller workflow are installed in the build and test jobs.

This is for example useful to build certain python dependencies which depend on C libraries which are not present by default.