### PR TITLE
Allow tests for Python 3.11 tests to fail

### DIFF
--- a/.github/workflows/dissect-ci-template.yml
+++ b/.github/workflows/dissect-ci-template.yml
@@ -76,6 +76,7 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,15 +84,19 @@ jobs:
           - python-version: "3.9"
             python-include: "python3.9"
             tox-env: "py39"
+            allow_failure: false
           - python-version: "3.10"
             python-include: "python3.10"
             tox-env: "py310"
+            allow_failure: false
           - python-version: "3.11"
             python-include: "python3.11"
             tox-env: "py311"
+            allow_failure: true 
           - python-version: "pypy3.9"
             python-include: "pypy3.9"
             tox-env: "pypy39"
+            allow_failure: false
     steps:
       - if: ${{ inputs.run_tests == true && inputs.deb-packages != '' }}
         run: sudo apt-get install -qq ${{ inputs.deb-packages }}


### PR DESCRIPTION
The pathlib implementation of Python 3.11 is still in flux, which may lead to test errors.

As this versions is not yet officially supported fr Dissect, merging & publishing should be allowed to continue even though these tests fail.

(DIS-2039)