### PR TITLE
Fix on-demand-test workflow

### DIFF
--- a/.github/workflows/dissect-ci-demand-test-template.yml
+++ b/.github/workflows/dissect-ci-demand-test-template.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           curl \
                --no-progress-meter \
+               --fail-with-body \
                -X POST \
                -H "Accept: application/vnd.github+json" \
                -H "Authorization: Bearer ${{ secrets.DISSECT_CI_DEMAND_TEST_PA_TOKEN }}" \


### PR DESCRIPTION
I choose for the --fail-with-body so we can see what/why it failed. 

Can also do it without body. 