### PR TITLE
Update tox version to 4.27.0

### DIFF
--- a/.github/actions/tox-run/action.yml
+++ b/.github/actions/tox-run/action.yml
@@ -23,7 +23,7 @@ inputs:
   tox-version:
     description: Version of tox to install
     required: false
-    default: "4.4.3"
+    default: "4.27.0"
 
 runs:
   using: composite


### PR DESCRIPTION
So that we can use `dependency_groups`.

Closes https://github.com/fox-it/dissect-workflow-templates/issues/48.